### PR TITLE
Update Composer.json and Removed Package Duplication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "require": {
         "turso/libsql": "dev-master",
         "illuminate/database": "^11.0",
-        "spatie/laravel-package-tools": "^1.16",
-        "turso/libsql": "dev-master"
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",


### PR DESCRIPTION
As one of required package is already added in composer.json. So there is no need to duplicate. That's why it's removed